### PR TITLE
Ajouter TogglzButton.js — accès rapide à la console Togglz

### DIFF
--- a/TamperMonkey/development/TogglzButton.js
+++ b/TamperMonkey/development/TogglzButton.js
@@ -1,0 +1,67 @@
+// ==UserScript==
+// @name         Omnimed Togglz Button
+// @namespace    https://www.omnimed.com/
+// @version      0.1
+// @description  Add a button next to the patient search to open the Togglz console in a new tab
+// @author       Marc-Antoine Robert
+// @match        https://cloud.dev.omnimed.com/omnimed/*
+// @match        https://test.omnimed.com/omnimed/*
+// @match        https://itgr.omnimed.com/omnimed/*
+// @match        https://stage.omnimed.com/omnimed/*
+// @match        https://preprod.omnimed.com/omnimed/*
+// @match        https://www.omnimed.com/omnimed/*
+// @grant        none
+// @run-at       document-end
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    var BUTTON_ID = 'togglzHeaderButton';
+
+    function addTogglzButton() {
+        var searchContainer = document.getElementById('headerSearchContainer');
+        if (!searchContainer || document.getElementById(BUTTON_ID)) {
+            return;
+        }
+
+        var button = document.createElement('a');
+        button.id = BUTTON_ID;
+        button.href = window.location.origin + '/omnimed/togglz';
+        button.target = '_blank';
+        button.rel = 'noopener';
+        button.title = 'Togglz';
+        button.style.cssText = [
+            'display: inline-flex',
+            'align-items: center',
+            'justify-content: center',
+            'vertical-align: middle',
+            'width: 28px',
+            'height: 28px',
+            'margin-left: 8px',
+            'border-radius: 50%',
+            'background-color: rgba(255, 255, 255, 0.15)',
+            'cursor: pointer'
+        ].join(';');
+
+        // Toggle switch icon
+        button.innerHTML =
+            '<svg viewBox="0 0 24 24" width="18" height="18" fill="#ffffff">' +
+            '<path d="M17 7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h10c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 8c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"/>' +
+            '</svg>';
+
+        button.addEventListener('mouseenter', function() {
+            button.style.backgroundColor = 'rgba(255, 255, 255, 0.3)';
+        });
+        button.addEventListener('mouseleave', function() {
+            button.style.backgroundColor = 'rgba(255, 255, 255, 0.15)';
+        });
+
+        searchContainer.appendChild(button);
+    }
+
+    addTogglzButton();
+
+    // The header can be re-rendered by JSF ajax updates; re-add the button if it disappears
+    new MutationObserver(addTogglzButton).observe(document.body, { childList: true, subtree: true });
+})();


### PR DESCRIPTION
## Description

Nouveau userscript Tampermonkey `TamperMonkey/development/TogglzButton.js` qui ajoute un petit bouton rond (icône toggle) à droite de la recherche patient dans le header.

- Ouvre `/omnimed/togglz` **dans un nouvel onglet**, sur le même origin que la page courante (pointe donc automatiquement vers la console Togglz du bon environnement)
- Fonctionne sur clouddev, test, itgr, stage, preprod et prod (`@match` par hostname)
- Un `MutationObserver` ré-ajoute le bouton si le header est re-rendu par un update Ajax JSF

<img width="949" height="72" alt="image" src="https://github.com/user-attachments/assets/eb86a8e3-84a4-4dfb-a973-2e0226787c15" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)