### PR TITLE
Corrige les scripts de création de branche Jenkins pour les paramètres actuels du job

### DIFF
--- a/TamperMonkey/development/JenkinsCreateFeatureBranch.js
+++ b/TamperMonkey/development/JenkinsCreateFeatureBranch.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jenkins create feature branch
 // @namespace    http://tampermonkey.net/
-// @version      1.4
+// @version      1.6
 // @author       mplante
 // @match        https://jenkins.omnimed.com/job/CreateFeatureBranch/build?delay=0sec*
 // @match        https://jenkins.omnimed.com/*/job/CreateFeatureBranch/build?delay=0sec*
@@ -12,21 +12,61 @@
 (function() {
     'use strict';
 
-    var currentLength = 0
-    var branchNameInput = document.getElementsByName('value')[3];
-    var div = document.createElement('div');
     var maxLength = 67;
+    var FEATURE_NAME_PARAM = 'featureName';
+    var PREFILLABLE_PARAMS = ['targetBranch', 'teamName', 'ticketNumber', 'featureName'];
 
-    branchNameInput.addEventListener("input", updateLength);
+    // Jenkins does NOT pre-fill this confirmation page's fields from the
+    // request's query string on its own (verified: ?targetBranch=master is
+    // silently ignored, dropdown stays on its default). So we do it
+    // ourselves: read the query string and set each parameter's field.
+    //
+    // Jenkins renders each parameter as a block containing a hidden
+    // input[name="name"] holding the parameter name, and a sibling
+    // input/select[name="value"] holding the actual value. Look the
+    // block up by parameter name instead of by position, since the
+    // number/order of parameters on this job has changed before.
+    function findParamValueInput(paramName) {
+        var nameInputs = document.getElementsByName('name');
+        for (var i = 0; i < nameInputs.length; i++) {
+            if (nameInputs[i].value === paramName) {
+                var block = nameInputs[i].closest('.jenkins-form-item') || nameInputs[i].parentElement;
+                return block ? block.querySelector('[name="value"]') : null;
+            }
+        }
+        return null;
+    }
 
-    div.innerHTML = "<div id='branchNameLength'></div>";
-    document.getElementsByName('parameter')[3].appendChild(div);
+    function prefillFromQueryString() {
+        var query = new URLSearchParams(window.location.search);
+        PREFILLABLE_PARAMS.forEach(function(paramName) {
+            if (!query.has(paramName)) return;
+            var input = findParamValueInput(paramName);
+            if (!input) return;
+            input.value = query.get(paramName);
+            var eventType = input.tagName === 'SELECT' ? 'change' : 'input';
+            input.dispatchEvent(new Event(eventType, { bubbles: true }));
+        });
+    }
 
-    function updateLength(e) {
-        currentLength = e.target.value.length;
-        document.getElementById("branchNameLength").innerHTML = currentLength + "/" + maxLength;
-    };
+    function addFeatureNameCounter() {
+        var featureNameInput = findParamValueInput(FEATURE_NAME_PARAM);
+        if (!featureNameInput) return;
 
-    document.getElementById("branchNameLength").innerHTML = branchNameInput.value.length + "/" + maxLength;
+        var paramBlock = featureNameInput.closest('.jenkins-form-item') || featureNameInput.parentElement;
 
+        var div = document.createElement('div');
+        div.id = 'branchNameLength';
+        paramBlock.appendChild(div);
+
+        function updateLength(e) {
+            div.innerHTML = e.target.value.length + "/" + maxLength;
+        }
+
+        featureNameInput.addEventListener("input", updateLength);
+        div.innerHTML = featureNameInput.value.length + "/" + maxLength;
+    }
+
+    prefillFromQueryString();
+    addFeatureNameCounter();
 })();

--- a/TamperMonkey/development/JiraCreateBranchOnJenkins.js
+++ b/TamperMonkey/development/JiraCreateBranchOnJenkins.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jira Hijack Create Branch Link
 // @namespace    http://tampermonkey.net/
-// @version      1.3
+// @version      1.4
 // @description  Hijack Jira's Create Branch link, generate branch name, and pass to Jenkins
 // @author       msamson
 // @match        https://omnimedjira.atlassian.net/*
@@ -19,18 +19,24 @@
     const SELECTOR_FOR_TEAM = '[data-testid="issue-field-team.ui.view-team-name"]';
     const SELECTOR_FOR_TITLE = '[data-testid="issue.views.issue-base.foundation.summary.heading"]';
 
-    const JENKINS_URL_BASE = "https://jenkins.omnimed.com/job/CreateFeatureBranch/build?delay=0sec&branchName=";
-    const TEAM_TAG_MAP = {
-        "Brainiacs": "ai",
-        "Chill Pills": "cp",
-        "DaftPunk": "dp",
-        "ETL": "etl",
-        "Gate Keepers": "gk",
-        "QA": "qa",
-        "Requesters": "req",
-        "Starship Troopers": "st",
-        "Time Twisters": "tt",
+    const JENKINS_URL_BASE = "https://jenkins.omnimed.com/job/CreateFeatureBranch/build?delay=0sec&";
+    const FEATURE_NAME_MAX_LENGTH = 67;
 
+    // Values must match the <option> values of the "teamName" dropdown on the
+    // Jenkins CreateFeatureBranch parameterized-build page (verified live:
+    // brainiacs, chillpills, daftpunk, ETL, qa, requesters, starshiptroopers,
+    // gatekeepers, timetwisters — no other values are valid).
+    const TEAM_TAG_MAP = {
+        "Brainiacs": "brainiacs",
+        "Chill Pills": "chillpills",
+        "Chill Bills": "chillpills", // Chill Pills/Chill Bills aren't officially split in Jenkins yet; both use chillpills
+        "DaftPunk": "daftpunk",
+        "ETL": "ETL",
+        "Gate Keepers": "gatekeepers",
+        "QA": "qa",
+        "Requesters": "requesters",
+        "Starship Troopers": "starshiptroopers",
+        "Time Twisters": "timetwisters",
     };
 
     function kebabify(text) {
@@ -41,7 +47,7 @@
                    .replace(/-+/g, '-');
     }
 
-    function getTeamTagFromComponent() {
+    function getTeamNameFromComponent() {
         const componentElem = document.querySelector(SELECTOR_FOR_TEAM);
         const component = componentElem?.innerText.trim();
         return TEAM_TAG_MAP[component] || component;
@@ -58,15 +64,23 @@
 
             const issueKey = document.querySelector(SELECTOR_FOR_ISSUE)?.innerText.trim();
             const title = document.querySelector(SELECTOR_FOR_TITLE)?.innerText.trim();
-            const teamTag = getTeamTagFromComponent();
+            const teamName = getTeamNameFromComponent();
 
-            if (!issueKey || !title || !teamTag) {
-                alert("Missing required Jira fields." + issueKey + " " + title + " " + teamTag);
+            if (!issueKey || !title || !teamName) {
+                alert("Missing required Jira fields." + issueKey + " " + title + " " + teamName);
+                return;
             }
 
             const ticketNumber = issueKey.split('-')[1]; // Get just the number
-            const branchName = `fd-${teamTag}-${ticketNumber}-${kebabify(title)}`;
-            const jenkinsUrl = `${JENKINS_URL_BASE}${encodeURIComponent(branchName)}`;
+            const featureName = kebabify(title).slice(0, FEATURE_NAME_MAX_LENGTH);
+
+            const params = new URLSearchParams({
+                teamName: teamName,
+                ticketNumber: ticketNumber,
+                featureName: featureName,
+            });
+
+            const jenkinsUrl = `${JENKINS_URL_BASE}${params.toString()}`;
 
             window.open(jenkinsUrl, "_blank");
         });


### PR DESCRIPTION
## Résumé
- Le job Jenkins `CreateFeatureBranch` attend maintenant `targetBranch`/`teamName`/`ticketNumber`/`featureName` au lieu d'un seul paramètre `branchName` — `JiraCreateBranchOnJenkins.js` générait une URL que Jenkins ignorait complètement.
- Correction de la table de correspondance des équipes pour qu'elle corresponde aux valeurs réelles du menu déroulant `teamName` (`brainiacs`, `chillpills`, `daftpunk`, `ETL`, `qa`, `requesters`, `starshiptroopers`, `gatekeepers`, `timetwisters`) ; "Chill Bills" correspond aussi à `chillpills` puisque l'équipe n'est pas encore scindée de "Chill Pills" dans Jenkins.
- `JenkinsCreateFeatureBranch.js` retrouve maintenant le champ `featureName` par son nom de paramètre plutôt que par un index codé en dur, et applique lui-même les paramètres de l'URL au formulaire — Jenkins ne pré-remplit pas les champs de cette page à partir de l'URL.

## Plan de test
- [x] Vérifié en direct sur un vrai ticket Jira (DEV-36716) : cliquer sur « Create branch in GitHub » ouvre Jenkins avec `teamName`, `ticketNumber`, `featureName` correctement pré-remplis et le compteur `X/67` fonctionnel sur `featureName`.
- [ ] À confirmer par le reviewer sur un autre ticket/équipe avant de merger.