### PR TITLE
Renomme le lien « Create branch in GitHub » en « Create branch in Jenkins »

### DIFF
--- a/TamperMonkey/development/JiraCreateBranchOnJenkins.js
+++ b/TamperMonkey/development/JiraCreateBranchOnJenkins.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jira Hijack Create Branch Link
 // @namespace    http://tampermonkey.net/
-// @version      1.4
+// @version      1.5
 // @description  Hijack Jira's Create Branch link, generate branch name, and pass to Jenkins
 // @author       msamson
 // @match        https://omnimedjira.atlassian.net/*
@@ -53,10 +53,25 @@
         return TEAM_TAG_MAP[component] || component;
     }
 
+    // "GitHub" is kept untranslated by Atlassian's localized UI strings, so a
+    // plain substring swap works no matter what language Jira is displayed in.
+    function relabelGithubToJenkins(el) {
+        for (const node of el.childNodes) {
+            if (node.nodeType === Node.TEXT_NODE) {
+                if (node.textContent.includes('GitHub')) {
+                    node.textContent = node.textContent.replace(/GitHub/g, 'Jenkins');
+                }
+            } else {
+                relabelGithubToJenkins(node);
+            }
+        }
+    }
+
     function hijackCreateBranchLink() {
         const link = document.querySelector(SELECTOR_CREATE_BRANCH);
         if (!link || link.classList.contains('hijacked')) return;
 
+        relabelGithubToJenkins(link);
         link.classList.add('hijacked');
         link.addEventListener('click', function (e) {
             e.preventDefault();


### PR DESCRIPTION
## Résumé
- Le lien du panneau Development redirige en réalité vers Jenkins, pas GitHub — son libellé « Create branch in GitHub » était trompeur.
- Ajout de `relabelGithubToJenkins()` : remplace le texte « GitHub » par « Jenkins » dans les nœuds texte du lien. « GitHub » n'étant jamais traduit dans l'UI localisée d'Atlassian, ça fonctionne peu importe la langue de Jira.
- Idempotent : le remplacement de texte ne fait rien si « GitHub » n'est plus présent, donc pas de problème si le MutationObserver retraite le même lien plusieurs fois.

## Plan de test
- [x] Vérifié en direct sur DEV-36716 : le libellé passe de « Create branch in GitHub » à « Create branch in Jenkins », et rejouer la fonction une seconde fois ne change plus rien (idempotence confirmée par script).
- [ ] À confirmer par le reviewer.